### PR TITLE
fix: drop nan values when constructing streamlit map

### DIFF
--- a/src/analysis/query_duckdb_garmin.py
+++ b/src/analysis/query_duckdb_garmin.py
@@ -66,6 +66,7 @@ with duckdb.connect("./data/garmin_pipeline.duckdb") as conn:
     run_df = run_df[['start_latitude', 'start_longitude']]
     ## Create a map with the data    
     run_df.columns = ['latitude', 'longitude']
+    run_df.dropna(subset=['latitude', 'longitude'], inplace=True)
     ## Create a map with the data
     st.map(run_df)
 


### PR DESCRIPTION
This small fix addresses issue #1. 

While testing the app, I noticed that my personal Garmin data has some nan values in 'latitude' and 'longitude'. This might be due to a manually added activity during the recent [Garmin outage](https://www.tomsguide.com/news/live/garmin-outage-jan-2025-blue-triangle) which had no location data in it. 

These nan values made the Streamlit map crash. The solution is to just drop nan values from the latitude-longitude dataframe before feeding them to the map.